### PR TITLE
Add rust src to package set

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -80,7 +80,7 @@ rec {
   # `cargo build` with in the shell should just work.
   shell = pkgs.mkShell {
     inputsFrom = pkgs.lib.mapAttrsToList (_: pkg: pkg { }) rustPkgs.noBuild.workspace;
-    nativeBuildInputs = with rustPkgs; [ cargo rustc ];
+    nativeBuildInputs = with rustPkgs; [ cargo rustc rust-src ];
   };
   examples =
     let

--- a/overlay/make-package-set/full.nix
+++ b/overlay/make-package-set/full.nix
@@ -11,6 +11,7 @@
   packageFun,
   cargo,
   rustc,
+  rust-src,
   buildRustPackages ? null,
   localPatterns ? [ ''^(src|tests)(/.*)?'' ''[^/]*\.(rs|toml)$'' ],
   packageOverrides ? rustBuilder.overrides.all,
@@ -35,7 +36,7 @@ lib.fix' (self:
           pkgsHostTarget = scope;
           pkgsTargetTarget = {};
         } // {
-          inherit (scope) pkgs buildRustPackages cargo rustc config __splicedPackages;
+          inherit (scope) pkgs buildRustPackages cargo rustc rust-src config __splicedPackages;
         };
       in
         prevStage // prevStage.xorg // prevStage.gnome2 // { inherit stdenv; } // scopeSpliced;
@@ -59,7 +60,7 @@ lib.fix' (self:
     });
 
   in packageFunWith { mkRustCrate = mkRustCrate'; buildRustPackages = buildRustPackages'; } // {
-    inherit rustPackages callPackage cargo rustc pkgs;
+    inherit rustPackages callPackage cargo rustc rust-src pkgs;
     noBuild = packageFunWith {
       mkRustCrate = lib.makeOverridable mkRustCrateNoBuild { };
       buildRustPackages = buildRustPackages'.noBuild;

--- a/overlay/make-package-set/simplified.nix
+++ b/overlay/make-package-set/simplified.nix
@@ -14,7 +14,7 @@ let
   rustChannel = buildPackages.rustChannelOf {
     channel = args.rustChannel;
   };
-  inherit (rustChannel) cargo;
+  inherit (rustChannel) cargo rust-src;
   rustc = rustChannel.rust.override {
     targets = [
       (rustBuilder.rustLib.realHostTriple stdenv.targetPlatform)
@@ -23,10 +23,10 @@ let
   extraArgs = builtins.removeAttrs args [ "rustChannel" "packageFun" "packageOverrides" ];
 in
 rustBuilder.makePackageSet (extraArgs // {
-  inherit cargo rustc packageFun;
+  inherit cargo rustc rust-src packageFun;
   packageOverrides = packageOverrides pkgs;
   buildRustPackages = buildPackages.rustBuilder.makePackageSet (extraArgs // {
-    inherit cargo rustc packageFun;
+    inherit cargo rustc rust-src packageFun;
     packageOverrides = packageOverrides buildPackages;
   });
 })


### PR DESCRIPTION
This shortcut makes it easier to construct a shell with coordinated rust sources
for consumption in rust analyzer

The good part of https://github.com/tenx-tech/cargo2nix/pull/115/files