### PR TITLE
Udev and dbus overrides

### DIFF
--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -67,6 +67,7 @@ in rec {
     fsevent-sys
     libgit2-sys
     libdbus-sys
+    libudev-sys
     openssl-sys
     pkg-config
     pq-sys
@@ -108,6 +109,21 @@ in rec {
       propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
         pkgs.dbus
       ];
+    };
+  };
+
+  libudev-sys = pkgs.rustBuilder.rustLib.makeOverride {
+    name = "libudev-sys";
+    overrideAttrs = drv: {
+      propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
+        pkgs.udev
+      ];
+      buildPhase = ''
+        runHook overrideCargoManifest
+        runHook setBuildEnv
+        export PATH=$PATH:$(dirname $RUSTC)
+        runHook runCargo
+      '';
     };
   };
 

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -66,6 +66,7 @@ in rec {
     curl-sys
     fsevent-sys
     libgit2-sys
+    libdbus-sys
     openssl-sys
     pkg-config
     pq-sys
@@ -100,6 +101,15 @@ in rec {
       };
     }
     else  nullOverride;
+
+  libdbus-sys = pkgs.rustBuilder.rustLib.makeOverride {
+    name = "libdbus-sys";
+    overrideAttrs = drv: {
+      propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
+        pkgs.dbus
+      ];
+    };
+  };
 
   libgit2-sys = if pkgs.stdenv.hostPlatform.isDarwin
     then makeOverride {

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -90,14 +90,16 @@ in rec {
     };
   };
 
-  fsevent-sys = makeOverride {
-    name = "fsevent-sys";
-    overrideAttrs = drv: {
-      propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
-        pkgs.darwin.apple_sdk.frameworks.CoreServices
-      ];
-    };
-  };
+  fsevent-sys = if pkgs.stdenv.hostPlatform.isDarwin
+    then makeOverride {
+      name = "fsevent-sys";
+      overrideAttrs = drv: {
+        propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
+          pkgs.darwin.apple_sdk.frameworks.CoreServices
+        ];
+      };
+    }
+    else  nullOverride;
 
   libgit2-sys = if pkgs.stdenv.hostPlatform.isDarwin
     then makeOverride {


### PR DESCRIPTION
Two simple overrides and one drive-by override fixup.

Use of `$RUSTC` will fail if we ever switch how it's provided to the build env.  Recommend a followup PR to always provide `rustc` on the `$PATH` for other creative build.rs scripts which attempt to invoke it directly