### PR TITLE
Update copyright holders to indicate ownership transfer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 TenX Pte. Ltd.
+Copyright (c) 2020 The cargo2nix developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Changed

* Update `LICENSE` to credit the individual `cargo2nix` developers as copyright holders.