### PR TITLE
Temporarily pin examples to Rust 1.46.0

### DIFF
--- a/examples/1-hello-world/default.nix
+++ b/examples/1-hello-world/default.nix
@@ -20,7 +20,7 @@ let
   };
 
   rustPkgs = pkgs.rustBuilder.makePackageSet' {
-    rustChannel = "stable";
+    rustChannel = "1.46.0";
     packageFun = import ./Cargo.nix;
   };
 in

--- a/examples/2-bigger-project/default.nix
+++ b/examples/2-bigger-project/default.nix
@@ -20,7 +20,7 @@ let
   };
 
   rustPkgs = pkgs.rustBuilder.makePackageSet' {
-    rustChannel = "stable";
+    rustChannel = "1.46.0";
     packageFun = import ./Cargo.nix;
     # packageOverrides = pkgs: pkgs.rustBuilder.overrides.all; # Implied, if not specified
   };

--- a/examples/3-static-resources/default.nix
+++ b/examples/3-static-resources/default.nix
@@ -20,7 +20,7 @@ let
   };
 
   rustPkgs = pkgs.rustBuilder.makePackageSet' {
-    rustChannel = "stable";
+    rustChannel = "1.46.0";
     packageFun = import ./Cargo.nix;
     localPatterns = [
       ''^(src|tests|templates)(/.*)?''


### PR DESCRIPTION
This should hopefully unblock CI for us until we can upgrade to a newer verison of Cargo which supports Lockfile format V2.

We can revert this once #145 is resolved.