### PR TITLE
Update URLs to point to cargo2nix GitHub organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Rust crate should be added to the [overlay/overrides.nix] file. The fix will
 constitute at least a patch version bump to `cargo2nix`, since it is a fix of
 existing functionality.
 
-[overlay/overrides.nix]: https://github.com/tenx-tech/cargo2nix/blob/master/overlay/overrides.nix
+[overlay/overrides.nix]: https://github.com/cargo2nix/cargo2nix/blob/master/overlay/overrides.nix
 
 #### 2. Failure to build due to a defect in cargo2nix
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status][build-badge]][build-url]
 
-[build-badge]: https://circleci.com/gh/tenx-tech/cargo2nix.svg?style=shield
-[build-url]: https://circleci.com/gh/tenx-tech/cargo2nix
+[build-badge]: https://circleci.com/gh/cargo2nix/cargo2nix.svg?style=shield
+[build-url]: https://circleci.com/gh/cargo2nix/cargo2nix
 
 [Nixify](https://nixos.org/nix) your Rust projects today with `cargo2nix`,
 bringing you reproducible builds and better caching.
@@ -25,7 +25,7 @@ This project assumes that the [Nix package manager](https://nixos.org/nix) is
 already installed on your machine. Run the command below to install `cargo2nix`:
 
 ```bash
-nix-env -iA package -f https://github.com/tenx-tech/cargo2nix/tarball/master
+nix-env -iA package -f https://github.com/cargo2nix/cargo2nix/tarball/master
 ```
 
 ## How to use this for your Rust projects

--- a/examples/1-hello-world/README.md
+++ b/examples/1-hello-world/README.md
@@ -32,7 +32,7 @@ if it's not already present. This can be done by executing the following
 one-liner in your shell:
 
 ```bash
-nix-env -iA package -f https://github.com/tenx-tech/cargo2nix/tarball/master
+nix-env -iA package -f https://github.com/cargo2nix/cargo2nix/tarball/master
 ```
 
 Once it's installed, we can move on to creating the Cargo project we wish to
@@ -126,7 +126,7 @@ with the following arguments:
     rev = "50bae918794d3c283aeb335b209efd71e75e3954";
   },
   cargo2nix ? builtins.fetchGit {
-    url = https://github.com/tenx-tech/cargo2nix;
+    url = https://github.com/cargo2nix/cargo2nix;
     ref = "v0.9.0";
   },
 }:
@@ -160,7 +160,7 @@ we fetch from the Git tag `v0.8.3`.
 Next, we need to write the body of our function. To do this, we declare a `let`
 block and import [Nixpkgs] using our three function arguments from earlier:
 
-[cargo2nix]: https://github.com/tenx-tech/cargo2nix
+[cargo2nix]: https://github.com/cargo2nix/cargo2nix
 [Nixpkgs]: https://github.com/NixOS/nixpkgs
 
 ```nix

--- a/examples/1-hello-world/default.nix
+++ b/examples/1-hello-world/default.nix
@@ -5,7 +5,7 @@
     rev = "18cd4300e9bf61c7b8b372f07af827f6ddc835bb";
   },
   cargo2nix ? builtins.fetchGit {
-    url = https://github.com/tenx-tech/cargo2nix;
+    url = https://github.com/cargo2nix/cargo2nix;
     # TODO: pin to tag once v0.9.0 is released
     ref = "ada69dafa095da4133a42abb292f22f12f2c4f36";
   },

--- a/examples/2-bigger-project/README.md
+++ b/examples/2-bigger-project/README.md
@@ -125,7 +125,7 @@ following arguments:
     rev = "50bae918794d3c283aeb335b209efd71e75e3954";
   },
   cargo2nix ? builtins.fetchGit {
-    url = https://github.com/tenx-tech/cargo2nix;
+    url = https://github.com/cargo2nix/cargo2nix;
     ref = "v0.9.0";
   },
 }:

--- a/examples/2-bigger-project/default.nix
+++ b/examples/2-bigger-project/default.nix
@@ -5,7 +5,7 @@
     rev = "18cd4300e9bf61c7b8b372f07af827f6ddc835bb";
   },
   cargo2nix ? builtins.fetchGit {
-    url = https://github.com/tenx-tech/cargo2nix;
+    url = https://github.com/cargo2nix/cargo2nix;
     # TODO: pin to tag once v0.9.0 is released
     ref = "ada69dafa095da4133a42abb292f22f12f2c4f36";
   },

--- a/examples/3-static-resources/README.md
+++ b/examples/3-static-resources/README.md
@@ -171,7 +171,7 @@ following arguments:
     rev = "50bae918794d3c283aeb335b209efd71e75e3954";
   },
   cargo2nix ? builtins.fetchGit {
-    url = https://github.com/tenx-tech/cargo2nix;
+    url = https://github.com/cargo2nix/cargo2nix;
     ref = "v0.9.0";
   },
 }:

--- a/examples/3-static-resources/default.nix
+++ b/examples/3-static-resources/default.nix
@@ -5,7 +5,7 @@
     rev = "18cd4300e9bf61c7b8b372f07af827f6ddc835bb";
   },
   cargo2nix ? builtins.fetchGit {
-    url = https://github.com/tenx-tech/cargo2nix;
+    url = https://github.com/cargo2nix/cargo2nix;
     # TODO: pin to tag once v0.9.0 is released
     ref = "ada69dafa095da4133a42abb292f22f12f2c4f36";
   },


### PR DESCRIPTION
### Changed

* Update all older GitHub URLs containing `tenx-tech` to point to this our new GitHub organization.

### Fixed

* Fix CircleCI status badge because `tenx-tech` no longer controls this repository.