### PR TITLE
Multiple Outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/target
 **/*.rs.bk
 **/result
+**/result-bin
 
 .direnv/

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -240,6 +240,8 @@ let
       runHook runCargo
     '';
 
+    outputs = ["out" "bin"];
+
     installPhase = ''
       mkdir -p $out/lib
       cargo_links="$(remarshal -if toml -of json Cargo.original.toml | jq -r '.package.links | select(. != null)')"


### PR DESCRIPTION
Multiple outputs allows cleaner installation of programs into nix profiles side
by side without collisions between files used only at build time but are
necessary between dependencies and aren't separated into their own
nativeBuildInput.  Examples include .linked_libs, .dep-keys, .cargo-build-output
and others that shouldn't go into result-bin

Nix throws an error if no directory is created by the builder for an expected
output, so the builders have to make both output dirs.

IIRC the repo is using pre-1.41 Rust and therefore uses the older install_crate,
so it only knows if a file is executible or not.  Whatever would go into $bin
for many build dependencies is also necessary in $out to complete builds without
error.

Build succeeds with 1.37.0 and 1.42.0 to try and test `install_crate2`