### PR TITLE
rustCrateSha256 for compatibility with flakes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,7 @@
   overlays ? [ ],
   crossSystem ? null,
   rustChannel ? "1.48.0",
+  rustChannelSha256 ? null,
 }:
 let
   # 1. Setup nixpkgs with nixpkgs-mozilla overlay and cargo2nix overlay.
@@ -29,6 +30,7 @@ let
   # - `packageFun` (required): The generated `Cargo.nix` file, which returns the whole dependency graph.
   # - `workspaceSrc` (optional): Sources for the workspace can be provided or default to the current directory.
   # - `rustChannel` (required): The Rust channel used to build the package set.
+  # - `rustChannelSha256` (optional): The Rust channel sha256, required when cargo2nix is a flake input.
   # - `packageOverrides` (optional):
   #     A function taking a package set and returning a list of overrides.
   #     Overrides are introduced to provide native inputs to build the crates generated in `Cargo.nix`.
@@ -55,7 +57,7 @@ let
   #     Crates that check for CPU features such as the `aes` crate will be evaluated against this argument.
   rustPkgs = pkgs.rustBuilder.makePackageSet' {
     packageFun = import ./Cargo.nix;
-    inherit rustChannel;
+    inherit rustChannel rustChannelSha256;
     packageOverrides = pkgs: pkgs.rustBuilder.overrides.all;
     localPatterns = [ ''^(src|tests|templates)(/.*)?'' ''[^/]*\.(rs|toml)$'' ];
   };

--- a/examples/2-bigger-project/default.nix
+++ b/examples/2-bigger-project/default.nix
@@ -21,6 +21,8 @@ let
 
   rustPkgs = pkgs.rustBuilder.makePackageSet' {
     rustChannel = "1.46.0";
+    # rustChannelSha256 is not nessesary, just for example
+    rustChannelSha256 = "xSLeZaUdE5l58YXyv772GQmmvn2W51wGNwrVP7d4qeo=";
     packageFun = import ./Cargo.nix;
     # packageOverrides = pkgs: pkgs.rustBuilder.overrides.all; # Implied, if not specified
   };

--- a/overlay/make-package-set/full.nix
+++ b/overlay/make-package-set/full.nix
@@ -11,6 +11,7 @@
   packageFun,
   workspaceSrc ? null,
   rustChannel,
+  rustChannelSha256 ? null,
   buildRustPackages ? null,
   localPatterns ? [ ''^(src|tests)(/.*)?'' ''[^/]*\.(rs|toml)$'' ],
   packageOverrides ? rustBuilder.overrides.all,
@@ -35,7 +36,7 @@ lib.fix' (self:
           pkgsHostTarget = scope;
           pkgsTargetTarget = {};
         } // {
-          inherit (scope) pkgs buildRustPackages rustChannel config __splicedPackages;
+          inherit (scope) pkgs buildRustPackages rustChannel rustChannelSha256 config __splicedPackages;
         };
       in
         prevStage // prevStage.xorg // prevStage.gnome2 // { inherit stdenv; } // scopeSpliced;
@@ -70,4 +71,6 @@ lib.fix' (self:
     mkRustCrate = mkRustCrate';
     buildRustPackages = buildRustPackages';
     __splicedPackages = defaultScope;
-  })
+  } // (if rustChannelSha256 != null then {
+    sha256 = rustChannelSha256;
+  } else {}))

--- a/overlay/make-package-set/simplified.nix
+++ b/overlay/make-package-set/simplified.nix
@@ -6,22 +6,25 @@
 }:
 args@{
   rustChannel,
+  rustChannelSha256 ? null,
   packageFun,
   workspaceSrc ? null,
   packageOverrides ? pkgs: pkgs.rustBuilder.overrides.all,
   ...
 }:
 let
-  rustChannel' = buildPackages.rustChannelOf {
+  rustChannel' = buildPackages.rustChannelOf ({
     channel = args.rustChannel;
-  };
+  } // (if rustChannelSha256 != null then {
+    sha256 = args.rustChannelSha256;
+  } else {}));
   inherit (rustChannel') cargo;
   rustc = rustChannel'.rust.override {
     targets = [
       (rustBuilder.rustLib.realHostTriple stdenv.targetPlatform)
     ];
   };
-  extraArgs = builtins.removeAttrs args [ "rustChannel" "packageFun" "packageOverrides" ];
+  extraArgs = builtins.removeAttrs args [ "rustChannel" "rustChannelSha256" "packageFun" "packageOverrides" ];
 in let
   rustChannel = rustChannel' // {inherit rustc cargo;};
 in rustBuilder.makePackageSet (extraArgs // {


### PR DESCRIPTION
When a package is built by flakes which require reproducible inputs including downloads via `fetchUrl` cargo2nix fails to build mozilla rust-overlay.
This PR introduces an option rustCrateSha256 which is being passed to rust-overlay to fix the problem mentioned above.