### PR TITLE
strip nulls from the outputs of the first jq pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,35 @@ the overlay builds the crate, cutting out guess work.
    `overlay/overrides.nix` for patterns of common solutions for fixing up
    specific deps.
    
+   To provide your own override, pass a modified `packageOverrides` to
+   `pkgs.rustBuilder.makePackageSet'`:
+   
+   ```nix
+     rustPkgs = pkgs.rustBuilder.makePackageSet' {
+       # ... required arguments not shown
+     
+       # Use the existing all list of overrides and append your override
+       packageOverrides = pkgs: pkgs.rustBuilder.overrides.all ++ [
+       
+         # parentheses disambiguate each makeOverride call as a single list element
+         (pkgs.rustBuilder.rustLib.makeOverride {
+             name = "fantasy-zlib-sys";
+             overrideAttrs = drv: {
+               propagatedNativeBuildInputs = drv.propagatedNativeBuildInputs or [ ] ++ [
+                 pkgs.zlib.dev
+               ];
+             };
+         })
+         
+       ];
+     };
+   ```
+   
+1. When re-vendoring nixpkgs-mozilla or cargo2nix, pay attention to the revs of
+   nixpkgs, the nixpkgs-mozilla overlay, and the cargo2nix overlay. Certain
+   non-release versions of nixpkgs-mozilla have shipped with a `rustc` that
+   doesn't include zlib in its runtime dependencies.
+   
 1. Many `crates.io` public crates may not build using the current Rust compiler,
    unless a lint cap is put on these crates. For instance, `cargo2nix` caps all
    lints to `warn` by default.

--- a/README.md
+++ b/README.md
@@ -119,22 +119,14 @@ the overlay builds the crate, cutting out guess work.
    unless a lint cap is put on these crates. For instance, `cargo2nix` caps all
    lints to `warn` by default.
 
-1. Nix 2.1.3 ships with a broken `builtins.fromTOML` function which is unable to
-   parse lines of TOML that look like this:
-
-   ```toml
-   [target.'cfg(target_os = "linux")'.dependencies.rscam]
-   ```
-
-   If Nix fails to parse your project's `Cargo.toml` manifest with an error
-   similar to the one below, please upgrade to a newer version of Nix. Versions
-   2.3.1 and newer are not affected by this bug. If upgrading is not an option,
-   removing the inner whitespace from the problematic keys should work around
-   this issue.
-
-   ```text
-   error: while parsing a TOML string at /nix/store/.../overlay/mkcrate.nix:31:14: Bare key 'cfg(target_os = "linux")' cannot contain whitespace at line 45
-   ```
+1. Toml parsing / conversion issues `Error: Cannot convert data to TOML (Invalid
+   type <class 'NoneType'>)`
+   
+   `jq` and `remarshal` are used to read & modify toml files in some
+   cases. Lines of the form: ```[key."cfg(foo = \"a\", bar = \"b\"))".path]```
+   could produce breakage when `jq` output was fed back to `remarshal`. There
+   are workarounds in place to catch many cases. See #149 for more information
+   and report any newly found breakage until a total solution is in place.
 
 1. Git dependencies and crates from alternative Cargo registries rely on
    `builtins.fetchGit` to support fetching from private Git repositories. This

--- a/overlay/lib/fetch.nix
+++ b/overlay/lib/fetch.nix
@@ -10,7 +10,6 @@ rec {
     let
       inherit (buildPackages) runCommand jq remarshal;
       repo = builtins.fetchGit {
-        name = "${name}-${version}-src";
         inherit url rev;
       };
     in

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -174,7 +174,8 @@ let
               , test: .test
               , example: .example
               , bench: (if \"$registry\" == \"unknown\" then .bench else null end)
-              } + $manifestPatch" \
+              } | with_entries(select( .value != null ))
+              + $manifestPatch" \
         | remarshal -if json -of toml > Cargo.toml
     '';
 

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -180,6 +180,7 @@ let
               , bench: (if \"$registry\" == \"unknown\" then .bench else null end)
               } | with_entries(select( .value != null ))
               + $manifestPatch" \
+        | jq "del(.[][] | nulls)" \
         | remarshal -if json -of toml > Cargo.toml
     '';
 

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -167,6 +167,10 @@ let
         echo source = \"registry+''${registry}\" >> Cargo.lock
       fi
       mv Cargo.toml Cargo.original.toml
+      # Remarshal version cannot handle escaped double quotes in table key paths
+      while grep '\[[^"]*"[^\\"]*\\"[^\\"]*\\"[^"]*[^]]*\]' Cargo.original.toml; do
+        sed -i -r 's/\[([^"]*)"([^\\"]*)\\"([^\\"]*)\\"([^"]*)"([^]]*)\]/[\1"\2'"'"'\3'"'"'\4"\5]/g' Cargo.original.toml
+      done;
       remarshal -if toml -of json Cargo.original.toml \
         | jq "{ package: .package
               , lib: .lib

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -169,6 +169,7 @@ in rec {
           { name = "RUSTFLAGS"; value = "--cfg ossl111 --cfg ossl110 --cfg ossl101";}
           { name = "${envize pkgs.stdenv.buildPlatform.config}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs.buildPackages); }
           { name = "${envize pkgs.stdenv.hostPlatform.config}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs); }
+          { name = "OPENSSL_NO_VENDOR"; value = "1";} # fixed 0.9.60
         ])
       ];
     };

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -4,7 +4,11 @@ let
   envize = s: builtins.replaceStrings ["-"] ["_"] (lib.toUpper s);
 
   patchOpenssl = pkgs:
-    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform
+    if pkgs.stdenv.hostPlatform.libc == "musl"
+    then pkgs.openssl.override {
+      static = true;
+    }
+    else if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform
     then pkgs.openssl
     else (pkgs.openssl.override {
       # We only need `perl` at build time. It's also used as the interpreter for one


### PR DESCRIPTION
These were breaking the version of remarshal in use

Fixes #149 
Fixes #172
Fixes #167

Getting this into CI while I figure out what was broken.  All output from jq would have contained these nulls and it should have been breaking more