### PR TITLE
Fix missing benchmark dependencies

### DIFF
--- a/overlay/mkcrate-nobuild.nix
+++ b/overlay/mkcrate-nobuild.nix
@@ -25,7 +25,7 @@ let
       (partition (drv: drv.stdenv.hostPlatform == stdenv.hostPlatform)
         (concatLists [
           (attrValues dependencies)
-          (optionals (compileMode == "test") (attrValues devDependencies))
+          (optionals (compileMode == "test" || compileMode == "bench") (attrValues devDependencies))
           (attrValues buildDependencies)
         ])))
     runtimeDependencies buildtimeDependencies;

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -89,7 +89,7 @@ let
       (partition (drv: drv.stdenv.hostPlatform == stdenv.hostPlatform)
         (concatLists [
           (attrValues dependencies)
-          (optionals (compileMode == "test") (attrValues devDependencies))
+          (optionals (compileMode == "test" || compileMode == "bench") (attrValues devDependencies))
           (attrValues buildDependencies)
         ])))
     runtimeDependencies buildtimeDependencies;
@@ -125,7 +125,7 @@ let
 
     dependencies = depMapToList dependencies;
     buildDependencies = depMapToList buildDependencies;
-    devDependencies = depMapToList (optionalAttrs (compileMode == "test") devDependencies);
+    devDependencies = depMapToList (optionalAttrs (compileMode == "test" || compileMode == "bench") devDependencies);
 
     extraRustcFlags =
       optionals (hostPlatformCpu != null) ([("-Ctarget-cpu=" + hostPlatformCpu)]) ++


### PR DESCRIPTION
Benchmarks were missing `dev-dependencies`