### PR TITLE
Add cross compilation tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             cachix push cargo2nix -w &
             nix-build -A ci --show-trace
             nix-build -A examples -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/e34208e10033315fddf6909d3ff68e2d3cf48a23.tar.gz --show-trace
-            nix-shell --show-trace --run cargo2nix
+            nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/e34208e10033315fddf6909d3ff68e2d3cf48a23.tar.gz --show-trace --run cargo2nix 
           no_output_timeout: 5h
       - save_cache:
           key: nix-store

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             cachix push cargo2nix -w &
             nix-build -A ci --show-trace
             nix-build -A examples -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/e34208e10033315fddf6909d3ff68e2d3cf48a23.tar.gz --show-trace
-            nix-shell --show-trace --run exit
+            nix-shell --show-trace --run cargo2nix
           no_output_timeout: 5h
       - save_cache:
           key: nix-store

--- a/default.nix
+++ b/default.nix
@@ -100,4 +100,5 @@ rec {
           );
     in
       importExprsInDir ./examples;
+      
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,1 @@
-with import ./. { crossSystem = null; }; shell
+with import ./. { crossSystem = (import <nixpkgs> {}).lib.systems.examples.musl64; }; shell


### PR DESCRIPTION
It seems like some combo of nixpkgs x cargo2nix x rust doesn't work with musl64 anymore, so I'm going to add some tests to automate tracking down the issue