### PR TITLE
Add support for running doctest

### DIFF
--- a/overlay/lib/profiles.nix
+++ b/overlay/lib/profiles.nix
@@ -12,7 +12,7 @@ in
   # Decides which profile to use based on compile mode and whether release is enabled.
   # Ported from https://github.com/rust-lang/cargo/blob/rust-1.38.0/src/cargo/core/profiles.rs#L86.
   decideProfile = compileMode: release:
-    if compileMode == "test" || compileMode == "bench"
+    if compileMode == "test" || compileMode == "bench" || compileMode == "doctest"
       then if release then "bench" else "test"
     else if compileMode == "build" || compileMode == null
       then if release then "release" else "dev"


### PR DESCRIPTION
The existing `test` compile mode doesn't run doctests. This PR adds a new compile mode `doctest` , which runs doctests using cargo, and produces the test report in the output `results.json`

**This will succeed even if the tests fail**. This is by design. 

To fail on test failure, the report should be examined.