### PR TITLE
Allow direct configuration of target

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -11,6 +11,7 @@ args@{
   hostPlatform,
   hostPlatformCpu ? null,
   hostPlatformFeatures ? [],
+  target,
   mkRustCrate,
   rustLib,
   lib,
@@ -25,7 +26,7 @@ in let
   rootFeatures' = expandFeatures rootFeatures;
   overridableMkRustCrate = f:
     let
-      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures; } // (f profileName)));
+      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures target; } // (f profileName)));
     in { compileMode ? null, profileName ? decideProfile compileMode release }:
       let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in

--- a/examples/1-hello-world/Cargo.nix
+++ b/examples/1-hello-world/Cargo.nix
@@ -11,6 +11,7 @@ args@{
   hostPlatform,
   hostPlatformCpu ? null,
   hostPlatformFeatures ? [],
+  target,
   mkRustCrate,
   rustLib,
   lib,
@@ -25,7 +26,7 @@ in let
   rootFeatures' = expandFeatures rootFeatures;
   overridableMkRustCrate = f:
     let
-      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures; } // (f profileName)));
+      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures target; } // (f profileName)));
     in { compileMode ? null, profileName ? decideProfile compileMode release }:
       let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in

--- a/examples/2-bigger-project/Cargo.nix
+++ b/examples/2-bigger-project/Cargo.nix
@@ -11,6 +11,7 @@ args@{
   hostPlatform,
   hostPlatformCpu ? null,
   hostPlatformFeatures ? [],
+  target,
   mkRustCrate,
   rustLib,
   lib,
@@ -25,7 +26,7 @@ in let
   rootFeatures' = expandFeatures rootFeatures;
   overridableMkRustCrate = f:
     let
-      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures; } // (f profileName)));
+      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures target; } // (f profileName)));
     in { compileMode ? null, profileName ? decideProfile compileMode release }:
       let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in

--- a/examples/3-static-resources/Cargo.nix
+++ b/examples/3-static-resources/Cargo.nix
@@ -11,6 +11,7 @@ args@{
   hostPlatform,
   hostPlatformCpu ? null,
   hostPlatformFeatures ? [],
+  target,
   mkRustCrate,
   rustLib,
   lib,
@@ -25,7 +26,7 @@ in let
   rootFeatures' = expandFeatures rootFeatures;
   overridableMkRustCrate = f:
     let
-      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures; } // (f profileName)));
+      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures target; } // (f profileName)));
     in { compileMode ? null, profileName ? decideProfile compileMode release }:
       let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in

--- a/examples/4-independent-packaging/Cargo.nix
+++ b/examples/4-independent-packaging/Cargo.nix
@@ -41,6 +41,7 @@ args@{
   hostPlatform,
   hostPlatformCpu ? null,
   hostPlatformFeatures ? [],
+  target,
   mkRustCrate,
   rustLib,
   lib,
@@ -57,7 +58,7 @@ in let
   rootFeatures' = expandFeatures rootFeatures;
   overridableMkRustCrate = f:
     let
-      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures; } // (f profileName)));
+      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures target; } // (f profileName)));
     in { compileMode ? null, profileName ? decideProfile compileMode release }:
       let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in

--- a/overlay/make-package-set/full.nix
+++ b/overlay/make-package-set/full.nix
@@ -11,6 +11,7 @@
   packageFun,
   workspaceSrc ? null,
   rustChannel,
+  target,
   buildRustPackages ? null,
   localPatterns ? [ ''^(src|tests)(/.*)?'' ''[^/]*\.(rs|toml)$'' ],
   packageOverrides ? rustBuilder.overrides.all,
@@ -45,7 +46,7 @@ lib.fix' (self:
     mkRustCrate' = lib.makeOverridable (callPackage mkRustCrate { inherit rustLib; });
     combinedOverride = builtins.foldl' rustLib.combineOverrides rustLib.nullOverride packageOverrides;
     packageFunWith = { mkRustCrate, buildRustPackages }: lib.fix (rustPackages: packageFun {
-      inherit rustPackages buildRustPackages lib workspaceSrc;
+      inherit rustPackages buildRustPackages lib workspaceSrc target;
       inherit (stdenv) hostPlatform;
       mkRustCrate = rustLib.runOverride combinedOverride mkRustCrate;
       rustLib = rustLib // {

--- a/overlay/make-package-set/simplified.nix
+++ b/overlay/make-package-set/simplified.nix
@@ -9,6 +9,7 @@ args@{
   packageFun,
   workspaceSrc ? null,
   packageOverrides ? pkgs: pkgs.rustBuilder.overrides.all,
+  target ? (rustBuilder.rustLib.realHostTriple stdenv.targetPlatform),
   ...
 }:
 let
@@ -18,17 +19,18 @@ let
   inherit (rustChannel') cargo;
   rustc = rustChannel'.rust.override {
     targets = [
-      (rustBuilder.rustLib.realHostTriple stdenv.targetPlatform)
+      target
     ];
   };
-  extraArgs = builtins.removeAttrs args [ "rustChannel" "packageFun" "packageOverrides" ];
+  extraArgs = builtins.removeAttrs args [ "rustChannel" "packageFun" "packageOverrides" "target" ];
 in let
   rustChannel = rustChannel' // {inherit rustc cargo;};
 in rustBuilder.makePackageSet (extraArgs // {
-  inherit rustChannel packageFun workspaceSrc;
+  inherit rustChannel packageFun workspaceSrc target;
   packageOverrides = packageOverrides pkgs;
   buildRustPackages = buildPackages.rustBuilder.makePackageSet (extraArgs // {
     inherit rustChannel packageFun;
+    target = (rustBuilder.rustLib.realHostTriple stdenv.hostPlatform);
     packageOverrides = packageOverrides buildPackages;
   });
 })

--- a/overlay/mkcrate-nobuild.nix
+++ b/overlay/mkcrate-nobuild.nix
@@ -17,6 +17,7 @@
   rustcBuildFlags ? [ ],
   hostPlatformCpu ? null,
   hostPlatformFeatures ? [],
+  target
 }:
 with lib; with builtins;
 let

--- a/templates/Cargo.nix.tera
+++ b/templates/Cargo.nix.tera
@@ -13,6 +13,7 @@ args@{
   hostPlatform,
   hostPlatformCpu ? null,
   hostPlatformFeatures ? [],
+  target,
   mkRustCrate,
   rustLib,
   lib,
@@ -30,7 +31,7 @@ in let
   rootFeatures' = expandFeatures rootFeatures;
   overridableMkRustCrate = f:
     let
-      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures; } // (f profileName)));
+      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures target; } // (f profileName)));
     in { compileMode ? null, profileName ? decideProfile compileMode release }:
       let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in


### PR DESCRIPTION
This PR allows users to directly configure what target to build a Rust crate for. In the current version of `cargo2nix` you can cross-compile crates by using a Nix crossSystem, but that only lets you specify target types that are supported by Nix. At first this might sound like a contrived limitation, but there is a real use case for this, SGX builds. The Fortanix EDP uses a tier 3 target called `x86_64-fortanix-unknown-sgx`. Since there isn't a corresponding Nix system, you can't cross compile to the Fortanix ABI.

I solve this problem by allow configuration of build target in `mkCrate` and `makePackageSet`. This allows the user to pass in whatever target they please, with a fallback to the standard `realHostTriple` method. 

I am new to the `cargo2nix` project, so apologizes if I have made these changes in a clumsy manor, or not followed PR etiquette strictly. 