### PR TITLE
openssl-sys expects a rust triple

### DIFF
--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -178,8 +178,8 @@ in rec {
       propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
         (propagateEnv "openssl-sys" [
           { name = "RUSTFLAGS"; value = "--cfg ossl111 --cfg ossl110 --cfg ossl101";}
-          { name = "${envize pkgs.stdenv.buildPlatform.config}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs.buildPackages); }
-          { name = "${envize pkgs.stdenv.hostPlatform.config}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs); }
+          { name = "${envize (pkgs.rustBuilder.rustLib.rustTriple pkgs.stdenv.buildPlatform)}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs.buildPackages); }
+          { name = "${envize (pkgs.rustBuilder.rustLib.rustTriple pkgs.stdenv.hostPlatform)}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs); }
           { name = "OPENSSL_NO_VENDOR"; value = "1";} # fixed 0.9.60
         ])
       ];


### PR DESCRIPTION
`openssl-sys` expects a rust triple and not a nix triple.
The build break when the rust and the nix triple are different, for example on armv6.
It is the same kind of bugs as the one I fixed on #201.

This patch has been tested on our project where we use cargo2nix, openssl & cross compile to armv6:
  - this is what a failed build looks like, before the patch: [#1391](https://drone.deuxfleurs.fr/Deuxfleurs/garage/1391/5/3)
  - this is what a working build looks like, after the patch: [#1408](https://drone.deuxfleurs.fr/Deuxfleurs/garage/1408/5/3)
