### PR TITLE
Remove extraRustComponents from extraArgs

### DIFF
--- a/overlay/make-package-set/user-facing.nix
+++ b/overlay/make-package-set/user-facing.nix
@@ -20,6 +20,7 @@ let
   extraArgs = builtins.removeAttrs args [ "rustChannel"
                                           "rustVersion"
                                           "rustToolchain"
+                                          "extraRustComponents"
                                           "packageFun"
                                           "packageOverrides"
                                           "target"];


### PR DESCRIPTION
Resolves an issue where `makePackageSetInternal` is called with an unexpected argument when `extraRustComponents` is set.