### PR TITLE
use a more robust method to find crates in multi-crate workspaces

### DIFF
--- a/overlay/mkcrate-utils.sh
+++ b/overlay/mkcrate-utils.sh
@@ -296,3 +296,11 @@ cargoVerbosityLevel() {
 
   echo ${verbose_flag}
 }
+
+cargoRelativeManifest() {
+    local manifest_path=$(cargo metadata --format-version 1 --no-deps | jq -c ".packages[] | select(.name == \"$1\") | .manifest_path" | tr -d '"')
+    local workspace_path=$(cargo metadata --format-version 1 --no-deps | jq -c '.workspace_root' | tr -d '"')
+    workspace_path="${workspace_path%/}/"
+
+    echo "${manifest_path#"$workspace_path"}"
+}

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -159,13 +159,17 @@ let
     extraRustcBuildFlags = rustcBuildFlags;
 
     findCrate =  ''
-      if ! grep -lE 'name\s?=\s?"${name}"' Cargo.toml; then
+      . ${./mkcrate-utils.sh}
+      manifest_path=$(cargoRelativeManifest ${name})
+      manifest_dir=''${manifest_path%Cargo.toml}
+
+      if [ $manifest_path != "Cargo.toml" ]; then
         shopt -s globstar
         mv Cargo.toml Cargo.toml.workspace
         if [[ -d .cargo ]]; then
           mv .cargo .cargo.workspace
         fi
-        cd $(grep -lE 'name\s?=\s?"${name}"' **/Cargo.toml | xargs dirname)
+        cd "$manifest_dir"
       fi
     '';
 


### PR DESCRIPTION
### Motivation
Currently cargo2nix does not build any project which uses diesel. The method used to locate crates within a multi-crate workspace matches multiple crates. In this particular case, [grep](https://github.com/cargo2nix/cargo2nix/blob/5127b95a61bbf211f975ea9faf2fb31251a4a413/overlay/mkcrate.nix#L162) matches the crates diesel and diesel_cli. Therefore, the following `cd` command fails, since two paths are specified.

### Change
Instead of using a grep, use cargo metadata and parse the output with jq. 
