### PR TITLE
Run pre/post install hooks by default

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -314,7 +314,9 @@ let
 
     outputs = ["out" "bin"];
 
-    installPhase = if compileMode != "doctest" then ''
+    installPhase = ''
+      runHook preInstall
+    '' + (if compileMode != "doctest" then ''
       mkdir -p $out/lib
       cargo_links="$(remarshal -if toml -of json Cargo.original.toml | jq -r '.package.links | select(. != null)')"
       if (( MINOR_RUSTC_VERSION < 41 )); then
@@ -327,6 +329,8 @@ let
       mkdir -p $bin
       touch results.json
       mv results.json $out/share/
+    '') + ''
+      runHook postInstall
     '';
   };
 in


### PR DESCRIPTION
This is more consistent with the [nixpkgs manual][0]. Code adapted from [here in nixpkgs][1].

[0]: https://nixos.org/manual/nixpkgs/stable/#ssec-install-phase

[1]: https://github.com/NixOS/nixpkgs/blob/d8916eaeaf7080aa0642122d34d04f683ccf1f17/pkgs/stdenv/generic/setup.sh#L1134-L1155

Not sure if there are tests somewhere I need to update in this repository, though I did [test with my own code](https://or.computer.surgery/charles/cargo-shim/-/commit/1b4051ca1d698fcdd43fda674b500d01e3f43b63) that I originally wanted this feature for; you can try it yourself with `nix run 'git+https://or.computer.surgery/charles/cargo-shim?ref=cargo2nix-install-hooks'` (it just prints a help message then exits). You can tell it works because if it didn't, the rename would never happen and thus `nix run` would complain that it can't find the file specified in `apps.default.program`.

Fixes #275.