### PR TITLE
Copy WASM crate outputs

### DIFF
--- a/overlay/mkcrate-utils.sh
+++ b/overlay/mkcrate-utils.sh
@@ -136,7 +136,7 @@ install_crate2() {
   cp $(jq -rR 'fromjson?
     | select(.reason == "compiler-artifact")
     | .filenames
-    | map(select(test("\\.(a|rlib|so|dylib)$")))
+    | map(select(test("\\.(a|rlib|so|dylib|wasm)$")))
     | .[]' < .cargo-build-output) "$out/lib" 2> /dev/null || :
 
   jq -rR 'fromjson?
@@ -229,6 +229,7 @@ install_crate() {
           ;;
         a) ;&
         so) ;&
+        wasm) ;&
         dylib)
           mkdir -p "$out/lib"
           cp "$output" "$out/lib/"


### PR DESCRIPTION
This is fixing a missing piece in #203, which is to make sure that the generated Wasm file actually gets installed/copied.

We're successfully building Wasm now using this:

```
{
  inputs = {
    #cargo2nix.url = "github:cargo2nix/cargo2nix";
    cargo2nix.url = "/home/projects/cargo2nix";
    flake-utils.follows = "cargo2nix/flake-utils";
    nixpkgs.follows = "cargo2nix/nixpkgs";
  };

  outputs = inputs: with inputs;
    flake-utils.lib.eachDefaultSystem (system:
      let
        wasmTarget = "wasm32-unknown-unknown";

        pkgs = import nixpkgs {
          inherit system;
          overlays = [cargo2nix.overlays.default];
        };
        
        wasmPkgs = import nixpkgs {
          inherit system;
          crossSystem = {
            config = "wasm32-unknown-wasi-unknown";
            system = "wasm32-wasi";
            useLLVM = true;
          };
          overlays = [cargo2nix.overlays.default];
        };

        rustPkgs = pkgs.rustBuilder.makePackageSet {
          rustVersion = "1.61.0";
          packageFun = import ./Cargo.nix;
        };
        
        rustPkgsWasm = wasmPkgs.rustBuilder.makePackageSet {
          rustVersion = "1.61.0";
          packageFun = import ./Cargo.nix;
          target = "wasm32-unknown-unknown";
        };

      in rec {
        packages = {
          app = (rustPkgs.workspace.app {}).bin;
          wasm = (rustPkgsWasm.workspace.wasm {}).out;
          default = packages.app;
        };
      }
    );
}
```