### PR TITLE
Fix cross compiling for Fortanix SGX projects

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -184,7 +184,8 @@ let
       ]
 
     # HACK: 2019-08-01: wasm32-wasi always uses `wasm-ld`
-    '') + optionalString (rustBuildTriple != rustHostTriple && rustHostTriple != "wasm32-wasi" && rustHostTriple != "wasm32-unknown-unknown") (''
+    # HACK: 2021-12-29: x86_64-fortanix-unknown-sgx always use `ld`
+    '') + optionalString (rustBuildTriple != rustHostTriple && rustHostTriple != "wasm32-wasi" && rustHostTriple != "wasm32-unknown-unknown" && rustHostTriple != "x86_64-fortanix-unknown-sgx") (''
       [target."${rustHostTriple}"]
       linker = "${ccForHost}"
     ''+ optionalString (codegenOpts != null && codegenOpts ? "${rustHostTriple}") (''

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -47,6 +47,9 @@ fn cfg_to_expr(cfg: &CfgExpr, platform_var: &str) -> BoolExpr {
             ("target_os", v) => Single(format!("{}.parsed.kernel.name == {:?}", platform_var, v)),
             ("target_family", "unix") => Single(format!("{}.isUnix", platform_var)),
             ("target_family", "windows") => Single(format!("{}.isWindows", platform_var)),
+            ("target_env", "sgx") => {
+                Single(format!("target == {:?}", "x86_64-fortanix-unknown-sgx"))
+            }
             ("target_env", v) => Single(format!("{}.parsed.abi.name == {:?}", platform_var, v)),
             ("target_endian", "little") => Single(format!(
                 "{}.parsed.cpu.significantByte == {:?}",


### PR DESCRIPTION
This PR fixes two issues when cross compiling SGX projects. The first is that sgx requires a particular version of`ld`, similar to wasm-ld. The second is that the `sgx` triple does not get parsed properly, so a manual override needs to be mad