### PR TITLE
Deduplicate propagatedBuildInputs by store path

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -122,7 +122,13 @@ let
     name = "crate-${name}-${version}${optionalString (compileMode != "build") "-${compileMode}"}";
 
     buildInputs = runtimeDependencies ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
-    propagatedBuildInputs = (concatMap (drv: drv.propagatedBuildInputs) runtimeDependencies);
+    propagatedBuildInputs =
+      let
+        withRepeats = (concatMap (drv: drv.propagatedBuildInputs) runtimeDependencies);
+        byHash = listToAttrs (map (dep: { name = unsafeDiscardStringContext dep.outPath; value = dep; }) withRepeats);
+      in
+        attrValues byHash;
+
     nativeBuildInputs = [ rustToolchain ] ++ buildtimeDependencies;
 
     depsBuildBuild =


### PR DESCRIPTION
This is intended to fix https://github.com/cargo2nix/cargo2nix/issues/238. It works by using the nix store path to deduplicate the propagatedBuildInputs of each crate. Previously, a dense dependency graph could result in an exponentially large number of duplicate dependencies on packages like openssl or pkg-config. With this change, these dependencies get deduplicated and the exponential blowup is avoided.