### PR TITLE
use sqlx-macros overries for osx: SystemConfiguration

### DIFF
--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -82,6 +82,7 @@ in rec {
     rand
     rand_os
     rdkafka-sys
+    sqlx-macros
     reqwest
     ring
     zmq-sys
@@ -264,6 +265,15 @@ in rec {
       };
     }
     else nullOverride;
+
+  sqlx-macros = if pkgs.stdenv.hostPlatform.isDarwin
+  then makeOverride {
+    name = "sqlx-macros";
+    overrideAttrs = drv: {
+      propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [ pkgs.darwin.apple_sdk.frameworks.SystemConfiguration ];
+    };
+  }
+  else nullOverride;
 
   rdkafka-sys = makeOverride {
     name = "rdkafka-sys";


### PR DESCRIPTION
I came across another exception: `sqlx-macros` that require `SystemConfiguration.framework` on OSX.