### PR TITLE
Fix feature detection

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664231666,
-        "narHash": "sha256-5M/40aTCNC34lSPqZIS7zlldRa7n/yNKI1SrpSGAB34=",
+        "lastModified": 1672580127,
+        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "82379884b2e9cf1ba65f5b14bbcb9d1438abb745",
+        "rev": "0874168639713f547c05947c76124f78441ea46c",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664247556,
-        "narHash": "sha256-J4vazHU3609ekn7dr+3wfqPo5WGlZVAgV7jfux352L0=",
+        "lastModified": 1673231106,
+        "narHash": "sha256-Tbw4N/TL+nHmxF8RBoOJbl/6DRRzado/9/ttPEzkGr8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "524db9c9ea7bc7743bb74cdd45b6d46ea3fcc2ab",
+        "rev": "3488cec01351c2f1086b02a3a61808be7a25103e",
         "type": "github"
       },
       "original": {

--- a/overlay/make-package-set/internal.nix
+++ b/overlay/make-package-set/internal.nix
@@ -71,7 +71,7 @@ lib.fix' (self:
 
   in packageFunWith { mkRustCrate = mkRustCrate'; buildRustPackages = buildRustPackages'; } // {
     inherit rustPackages callPackage pkgs rustToolchain noBuild;
-    workspaceShell = workspaceShell { inherit pkgs noBuild rustToolchain; };
+    workspaceShell = workspaceShell { inherit pkgs rustPackages rustToolchain; };
     mkRustCrate = mkRustCrate';
     buildRustPackages = buildRustPackages';
     __splicedPackages = defaultScope;

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -286,6 +286,7 @@ let
       export NIX_RUST_LINK_FLAGS="''${linkFlags[@]} -L dependency=$(realpath deps) $extraRustcLinkFlags"
       export NIX_RUST_BUILD_FLAGS="''${buildLinkFlags[@]} -L dependency=$(realpath build_deps) $extraRustcBuildFlags"
       export RUSTC=${wrapper "rustc"}/bin/rustc
+      export CLIPPY_DRIVER=${wrapper "clippy-driver"}/bin/clippy-driver
       export RUSTDOC=${wrapper "rustdoc"}/bin/rustdoc
 
       depKeys=(`loadDepKeys $dependencies`)

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -121,6 +121,10 @@ let
     inherit src version meta NIX_DEBUG;
     name = "crate-${name}-${version}${optionalString (compileMode != "build") "-${compileMode}"}";
 
+    # Adding libiconv is a convenience hack.  It really isn't needed by every
+    # derivation and should instead be added / propagated where appropriate, but
+    # until someone decides to investigate the actual dependencies, it remains
+    # here instead of in overrides.
     buildInputs = runtimeDependencies ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
     propagatedBuildInputs = lib.unique (concatMap (drv: drv.propagatedBuildInputs) runtimeDependencies);
     nativeBuildInputs = [ rustToolchain ] ++ buildtimeDependencies;

--- a/overlay/workspace-shell.nix
+++ b/overlay/workspace-shell.nix
@@ -1,16 +1,98 @@
-{ pkgs, noBuild, rustToolchain }:
-args@{
-  inputsFrom ? [],
-  nativeBuildInputs ? [],
-  ...
-}:
+{ pkgs, rustPackages, rustToolchain }:
+# The resulting function is a decoration of mkShell.  Usually mkShell is only
+# given an inputsFrom that is a single package or packages without overlap in
+# dependencies.  However, we seek to provide a shell that is complete for every
+# rust crate in the entire workspace.  However, if we naively pass all rust
+# crates to inputsFrom, many dependencies will be duplicated via propagation or
+# multiple inclusion.  Therefore, instead create the dependency sets from the
+# rust crates are collected and de-duplicated before passing them to the normal
+# mkShell.  This is also done for the shellHook, just slightly differently.  The
+# source is really similar to nixpkgs mkShell that it decorates, so study one
+# and understand both.
+{ name ? "nix-shell"
+, # a list of packages to add to the shell environment
+  packages ? [ ]
+, # propagate all the inputs from the given derivations
+  inputsFrom ? [ ]
+, buildInputs ? [ ]
+, nativeBuildInputs ? [ ]
+, propagatedBuildInputs ? [ ]
+, propagatedNativeBuildInputs ? [ ]
+, ...
+}@attrs:
+let
+  lib = pkgs.lib;
 
-pkgs.mkShell (args // {
-  # `noBuild` is a special crate set used to create a development shell
-  # containing all native dependencies provided by the overrides above.
-  # `cargo build` within the shell should just work.
-  inputsFrom = (pkgs.lib.mapAttrsToList (_: pkg: pkg { }) noBuild.workspace) ++ inputsFrom;
-  nativeBuildInputs = [ rustToolchain ] ++ (with pkgs; [cacert]) ++ nativeBuildInputs;
+  # mkShell in the end will pass through arguments that it doesn't explicitly
+  # handle onward to mkDerivation.  Arguments removed at this point will be
+  # consumed and propagated by this function.
+  rest = builtins.removeAttrs attrs [
+    "buildInputs"
+    "nativeBuildInputs"
+    "propagatedBuildInputs"
+    "propagatedNativeBuildInputs"
+    "shellHook"
+  ];
+
+  # The crate functions from which we will gather the inputs must be called to
+  # yield finished crate derivations.  It is important to note that they will be
+  # called with their default arguments.  Augmentation of the crates which may
+  # affect their dependencies in the user's flake will result in inconsistency,
+  # so if such behavior exists or is added by the user, a mechanism must be
+  # introduced to propagate these effects on dependencies into the shell.
+
+  # TODO note that if package set is created from nixpkgs for another platform,
+  # it will be inappropriate for creating a workspace shell.  Flakes written for
+  # cross compilation but still get their workspaceShell from a package set for
+  # the build platform.
+
+  # TODO This is fragile because any path in the entire set that is not a crate
+  # function will cause failure.  Recent changes to overlay/make-package-set or
+  # overlay/default, even changes to Nix itself could add a path.  Replace this
+  # with some construct with no possibility of non-crate contamination.
+  crateFunctions = builtins.removeAttrs rustPackages
+    ["workspace"
+     "workspaceShell"
+     "cargo2nixVersion"
+     "rustToolchain"
+     "rustPackages"
+     "pkgs"
+     "noBuild"
+     "mkRustCrate"
+     "callPackage"
+     "buildRustPackages"
+     "__unfix__"
+     "__splicedPackages"];
+
+  # Note that out paths must match between the crate and the crates dependencies
+  # (crates depend on crate.out) or else you will get multiple inclusion and
+  # crates themselves in the shell depencnedies.  Cargo can build rust deps, so
+  # they are not needed in the development shell, nor will they be used by cargo
+  # outside of nix builds.
+  crates = map (pkg: (pkg { }).out) (pkgs.lib.collect builtins.isFunction crateFunctions);
+
+  # This function will extract the attr "name" from all crates, augment this
+  # list with the "name" from @attrs, remove explicit overlap with inputsFrom,
+  # and finally de-duplicate with unique.
+  mergeCrateInputs = name:
+    (lib.unique
+      (lib.subtractLists (packages ++ inputsFrom ++ crates)
+        ((attrs.${name} or [ ]) ++ (lib.flatten (lib.catAttrs name crates)))));
+
+in pkgs.mkShell (rest // {
+
+  # TODO investigate if cacert is needed or had been omitted in previous implementation
+  buildInputs = mergeCrateInputs "buildInputs";
+  nativeBuildInputs = (mergeCrateInputs "nativeBuildInputs") ++ [ rustToolchain ] ++ (with pkgs; [cacert]);
+  propagatedBuildInputs = mergeCrateInputs "propagatedBuildInputs";
+  propagatedNativeBuildInputs = mergeCrateInputs "propagatedNativeBuildInputs";
+
+  # Create a composite shellHook from the user passed shellHook and the rust
+  # crates' shellHooks.  This hook will be merged by mkShell with the shellHooks
+  # in inputsFrom
+  shellHook = lib.concatStringsSep "\n" (lib.unique (lib.catAttrs "shellHook"
+    (lib.reverseList crates ++ [ attrs ])));
+
   # Configures tools like Rust Analyzer to locate the correct rust-src
   RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
 })

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,7 @@ fn generate_cargo_nix(mut out: impl io::Write) -> Result<()> {
         &ws,
         &target_data,
         &requested_kinds,
-        &CliFeatures::new_all(false),
+        &CliFeatures::new_all(true),
         &specs,
         HasDevUnits::Yes,
         force_all,


### PR DESCRIPTION
Just to let you know @psionic-k that feature detection is currently broken in unstable. I had to change a line in `main.rs` to make it work, I'm not sure it's the correct fix but without that the `Cargo.nix` file I got didn't contain all possible feature flags but only those corresponding to default features.

Here is the broken `Cargo.nix` generated by `unstable` : https://git.deuxfleurs.fr/Deuxfleurs/garage/src/commit/7c0c2299349d81bdffe38f901770d501c5ad625f/Cargo.nix

Here is the correct `Cargo.nix` generatead with this patch : https://git.deuxfleurs.fr/Deuxfleurs/garage/src/commit/00cf076412b88ae0c6254fc16b9bbe661c4f01f2/Cargo.nix

The other line in `mkcrate.nix` is just for my personnal convenience so that I can use `clippy-driver` instead of `rustc` so that I  have all of the clippy lints in addition to standard rustc warnings when doing a build in our CI pipeline. See here for how we use it: https://git.deuxfleurs.fr/Deuxfleurs/garage/src/commit/00cf076412b88ae0c6254fc16b9bbe661c4f01f2/nix/compile.nix

I'm just opening this PR to open a discussion on this, not asking that you merge any of this in its current form.