### PR TITLE
Increase dependency limits

### DIFF
--- a/overlay/mkcrate-utils.sh
+++ b/overlay/mkcrate-utils.sh
@@ -184,11 +184,11 @@ install_crate2() {
     fi
   fi
 
-  loadExternCrateLinkFlags $dependencies >> "$out/lib/.link-flags"
+  loadExternCrateLinkFlags $(cat $dependenciesPath) >> "$out/lib/.link-flags"
 
   if (shopt -s failglob; : "$out/lib"/*.rlib) 2> /dev/null; then
     mkdir -p "$out/lib/deps"
-    linkExternCrateToDeps "$out/lib/deps" $dependencies
+    linkExternCrateToDeps "$out/lib/deps" $(cat $dependenciesPath)
   fi
 
   jq -n '{name:$name, metadata:$metadata, version:$version, proc_macro:$procmacro}' \
@@ -255,7 +255,7 @@ install_crate() {
   popd
 
   touch "$out/lib/.link-flags"
-  loadExternCrateLinkFlags $dependencies >> "$out/lib/.link-flags"
+  loadExternCrateLinkFlags $(cat $dependenciesPath) >> "$out/lib/.link-flags"
 
   if [ "$isProcMacro" ]; then
     pushd "target/${mode}"
@@ -286,7 +286,7 @@ install_crate() {
 
   if [ "$needs_deps" ]; then
     mkdir -p "$out/lib/deps"
-    linkExternCrateToDeps "$out/lib/deps" $dependencies
+    linkExternCrateToDeps "$out/lib/deps" $(cat $dependenciesPath)
   fi
 
   echo {} | jq \

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -119,6 +119,53 @@ let
         ])))
     runtimeDependencies buildtimeDependencies;
 
+  /*
+   * A copy of `symlinkJoin` from `nixpkgs` which passes the `paths` argument via a file
+   * instead of via an environment variable. This should fix the "Argument list too long"
+   * error when `paths` exceeds the limit.
+   *
+   * Code taken from https://github.com/nix-community/naersk/blob/master/build.nix
+   *
+   * Create a forest of symlinks to the files in `paths'.
+   *
+   * Examples:
+   * # adds symlinks of hello to current build.
+   * { symlinkJoin, hello }:
+   * symlinkJoin { name = "myhello"; paths = [ hello ]; }
+   *
+   * # adds symlinks of hello to current build and prints "links added"
+   * { symlinkJoin, hello }:
+   * symlinkJoin { name = "myhello"; paths = [ hello ]; postBuild = "echo links added"; }
+   */
+  symlinkJoinPassViaFile = args_ @ {
+    name,
+    paths,
+    preferLocalBuild ? true,
+    allowSubstitutes ? false,
+    postBuild ? "",
+    ...
+  }: let
+    args =
+      removeAttrs args_ ["name" "postBuild"]
+      // {
+        inherit preferLocalBuild allowSubstitutes;
+        passAsFile = ["paths"];
+      }; # pass the defaults
+  in
+    pkgs.runCommand name args
+    ''
+      mkdir -p $out
+      for i in $(cat $pathsPath); do
+        ${pkgs.buildPackages.xorg.lndir}/bin/lndir -silent $i $out
+      done
+      ${postBuild}
+    '';
+
+  propagatedBuildInputs = symlinkJoinPassViaFile {
+    name = "crate-${name}-${version}${optionalString (compileMode != "build") "-${compileMode}"}-deps";
+    paths = concatMap (drv: drv.propagatedBuildInputs) runtimeDependencies;
+  };
+
   drvAttrs = {
     inherit src version meta NIX_DEBUG;
     name = "crate-${name}-${version}${optionalString (compileMode != "build") "-${compileMode}"}";
@@ -128,7 +175,7 @@ let
     # until someone decides to investigate the actual dependencies, it remains
     # here instead of in overrides.
     buildInputs = runtimeDependencies ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
-    propagatedBuildInputs = lib.unique (concatMap (drv: drv.propagatedBuildInputs) runtimeDependencies);
+    propagatedBuildInputs = [propagatedBuildInputs];
     nativeBuildInputs = [ rustToolchain ] ++ buildtimeDependencies;
 
     depsBuildBuild =


### PR DESCRIPTION
Currently, there is a hard limit to how many direct and total dependencies a crate can have with cargo2nix, caused by linux argument length limits. Certain large crates with hundreds of total dependencies, like yew, cannot be built due to this.

This pull request changes dependency handling by symlinking the propagatedBuildInputs together in a separate build step. Additionally it instructs nix to pass the direct dependency list in as a file. This results in greatly increased dependency limits.

I have tested the changes and they do increase the dependency limits enough to build yew and crates that depend on it. This patch is applicable as-is against 0.11.0