### PR TITLE
Fix replaceChars -> replaceStrings

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -272,7 +272,7 @@ let
 
       crateName="$(
         remarshal -if toml -of json Cargo.original.toml \
-        | jq -r 'if .lib."name" then .lib."name" else "${replaceChars ["-"] ["_"] name}" end' \
+        | jq -r 'if .lib."name" then .lib."name" else "${replaceStrings ["-"] ["_"] name}" end' \
       )"
 
       . ${./mkcrate-utils.sh}


### PR DESCRIPTION
replaceChars is deprecated in nixos-unstable. Its use generates the following warning:

    trace: warning: replaceChars is a deprecated alias of replaceStrings, replace usages of it with replaceStrings.
