### PR TITLE
Fixes #317

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -293,7 +293,7 @@ let
       export CLIPPY_DRIVER=${wrapper "clippy-driver"}/bin/clippy-driver
       export RUSTDOC=${wrapper "rustdoc"}/bin/rustdoc
 
-      depKeys=(`loadDepKeys $dependencies`)
+      readarray -t depKeys <<< `loadDepKeys $dependencies`
 
       if (( NIX_DEBUG >= 1 )); then
         echo $NIX_RUST_LINK_FLAGS

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -315,7 +315,7 @@ let
           "CXX_${stdenv.buildPlatform.config}"="${cxxForBuild}" \
           "CC_${rustHostTriple}"="${ccForHost}" \
           "CXX_${rustHostTriple}"="${cxxForHost}" \
-          "''${depKeys[@]}" \
+          ''${depKeys:+"''${depKeys[@]}"} \
           ${buildCmd}
       )
     '';


### PR DESCRIPTION
```bash
depKeys=(`loadDepKeys $dependencies`)
```

breakes the output of `loadDepKeys $dependencies` according to bash rules and makes `DEP_GDK-3_BACKENDS='broadway wayland x11'` become 3 different entries in the array. This commit fixes that.