### PR TITLE
[mkcrate] replaceChars -> builtins.replaceStrings

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -272,7 +272,7 @@ let
 
       crateName="$(
         remarshal -if toml -of json Cargo.original.toml \
-        | jq -r 'if .lib."name" then .lib."name" else "${replaceChars ["-"] ["_"] name}" end' \
+        | jq -r 'if .lib."name" then .lib."name" else "${builtins.replaceStrings ["-"] ["_"] name}" end' \
       )"
 
       . ${./mkcrate-utils.sh}


### PR DESCRIPTION
Why
===
* nixpkgs warns about replaceChars being deprecated and replaces it with builtins.replaceStrings

> trace: warning: replaceChars is a deprecated alias of replaceStrings, replace usages of it with replaceStrings.

https://github.com/NixOS/nixpkgs/blob/45828de59578888e1cd08d9e06343b840e486cd8/lib/strings.nix#L548

replaceStrings was added in [version 1.10 in 2015](https://nixos.org/manual/nix/stable/release-notes/rl-1.10.html?highlight=replaceStrings#release-110-2015-09-03), so it should be safe to use.

What changed
===
* Replaced replaceChars with builtins.replaceStrings

