### PR TITLE
github actions: update actions; remove unneeded token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2.4.2
-      - uses: cachix/install-nix-action@v15
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v20
         with:
           extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             log-lines = 200
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: cargo2nix-gh
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
The actions were failing on my PR, so maybe bumping them will help

We don't need the token anymore since the action knows how to use a default token automatically.
https://github.com/cachix/install-nix-action/pull/157/files