### PR TITLE
 Use string interpolation to generate Cargo.lock path

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -26,7 +26,7 @@ args@{
 let
   nixifiedLockHash = "fbf68ebec2f381a3bd069b8aa1e63d2b08299f280bd9a5d4c5c30c1c5697f8a0";
   workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
-  currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
+  currentLockHash = builtins.hashFile "sha256" "${workspaceSrc}/Cargo.lock";
   lockHashIgnored = if ignoreLockHash
                   then builtins.trace "Ignoring lock hash" ignoreLockHash
                   else ignoreLockHash;

--- a/examples/1-hello-world/Cargo.nix
+++ b/examples/1-hello-world/Cargo.nix
@@ -26,7 +26,7 @@ args@{
 let
   nixifiedLockHash = "86421e8411c52265e52f81b8472270ebd2bf444f999c0a881d1c544b4e8a0d29";
   workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
-  currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
+  currentLockHash = builtins.hashFile "sha256" "${workspaceSrc}/Cargo.lock";
   lockHashIgnored = if ignoreLockHash
                   then builtins.trace "Ignoring lock hash" ignoreLockHash
                   else ignoreLockHash;

--- a/examples/2-bigger-project/Cargo.nix
+++ b/examples/2-bigger-project/Cargo.nix
@@ -26,7 +26,7 @@ args@{
 let
   nixifiedLockHash = "156d68c50b2caffb735aa9279e09fd6009a1d7bbf41863900d31309cf6b1f045";
   workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
-  currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
+  currentLockHash = builtins.hashFile "sha256" "${workspaceSrc}/Cargo.lock";
   lockHashIgnored = if ignoreLockHash
                   then builtins.trace "Ignoring lock hash" ignoreLockHash
                   else ignoreLockHash;

--- a/examples/3-cross-compiling/Cargo.nix
+++ b/examples/3-cross-compiling/Cargo.nix
@@ -26,7 +26,7 @@ args@{
 let
   nixifiedLockHash = "c787740d469acf71a36abd0a236a69f5b797b67eff93b9b6bd0321ea533a45ef";
   workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
-  currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
+  currentLockHash = builtins.hashFile "sha256" "${workspaceSrc}/Cargo.lock";
   lockHashIgnored = if ignoreLockHash
                   then builtins.trace "Ignoring lock hash" ignoreLockHash
                   else ignoreLockHash;

--- a/examples/4-independent-packaging/Cargo.nix
+++ b/examples/4-independent-packaging/Cargo.nix
@@ -66,7 +66,7 @@ args@{
 let
   nixifiedLockHash = "0da444f0704a804bb5bdf55c147e803cc7a578e96ea5ddeceb8937b783c7fd32";
   workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
-  currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
+  currentLockHash = builtins.hashFile "sha256" "${workspaceSrc}/Cargo.lock";
   lockHashIgnored = if ignoreLockHash
                   then builtins.trace "Ignoring lock hash" ignoreLockHash
                   else ignoreLockHash;

--- a/templates/Cargo.nix.tera
+++ b/templates/Cargo.nix.tera
@@ -28,7 +28,7 @@ args@{
 let
   nixifiedLockHash = "{{ cargo_lock_hash }}";
   workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
-  currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
+  currentLockHash = builtins.hashFile "sha256" "${workspaceSrc}/Cargo.lock";
   lockHashIgnored = if ignoreLockHash
                   then builtins.trace "Ignoring lock hash" ignoreLockHash
                   else ignoreLockHash;


### PR DESCRIPTION
When specifying a custom `workspaceSrc` 
```
pkgs.rustBuilder.makePackageSet {
  ...
  workspaceSrc = nix-filter {
    root = ./.;
    include = [
      "crates"
      ./Cargo.toml
      ./Cargo.lock
    ];
  };
}
```

`nix build` will fail with the following error

```
at /nix/store/yr2fm9jbvcvy4p55b6d1s4s5bx9pnhnz-source/Cargo.nix:40:21:

   39|   workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
   40|   currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
     |                     ^
   41|   lockHashIgnored = if ignoreLockHash

error: access to absolute path '/Cargo.lock' is forbidden in pure eval mode (use '--impure' to override)
```

If you do build with `--impure`, the build later fails at the same place, this time failing to find the directory

```
at /nix/store/x2ysy1n9p12jrfk1s5kaxjkwm9q22kgl-source/Cargo.nix:40:21:

   39|   workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
   40|   currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
     |                     ^
   41|   lockHashIgnored = if ignoreLockHash

error: getting status of '/Cargo.lock': No such file or directory
```

Both of these errors are because nix attempts to resolve the `/Cargo.lock` path used to lookup the lockfile as an absolute path on the file system, and fails. Instead we should use string interpolation to append the `/Cargo.lock` path to whatever path was passed in through the workspaceSrc.