### PR TITLE
Filter workspace source using lib.fileset

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -39,11 +39,17 @@ impl BuildPlan {
 
         let workspace_members = root_pkgs
             .into_iter()
-            .map(|pkg| Member {
-                name: pkg.name().to_string(),
-                version: pkg.version().to_string(),
+            .map(|pkg| {
+                Ok(Member {
+                    name: pkg.name().to_string(),
+                    version: pkg.version().to_string(),
+                    path: pathdiff::diff_paths(pkg.root(), cwd).ok_or(anyhow!(
+                        "path is not absolute for local package {:?}",
+                        pkg.root()
+                    ))?,
+                })
             })
-            .collect();
+            .collect::<Result<_>>()?;
 
         let crates = rpkgs_by_id
             .into_iter()
@@ -77,6 +83,7 @@ impl BuildPlan {
 pub struct Member {
     pub name: String,
     pub version: String,
+    pub path: PathBuf,
 }
 
 #[derive(Debug, Serialize)]

--- a/templates/Cargo.nix.tera
+++ b/templates/Cargo.nix.tera
@@ -27,7 +27,16 @@ args@{
 }:
 let
   nixifiedLockHash = "{{ cargo_lock_hash }}";
-  workspaceSrc = if args.workspaceSrc == null then ./. else args.workspaceSrc;
+  workspaceSrc = lib.fileset.toSource rec {
+    root = if args.workspaceSrc == null then ./. else args.workspaceSrc;
+    fileset = lib.fileset.unions [
+      (root + /Cargo.toml)
+      (root + /Cargo.lock)
+      {%- for crate in workspace_members %}
+      (root + /{{ crate.path }})
+      {%- endfor %}
+    ];
+  };
   currentLockHash = builtins.hashFile "sha256" (workspaceSrc + /Cargo.lock);
   lockHashIgnored = if ignoreLockHash
                   then builtins.trace "Ignoring lock hash" ignoreLockHash


### PR DESCRIPTION
Right now if any file in the workspace directory changes, Nix will rebuild all local crates. This becomes a problem in polyglot monorepos where all Rust packages get rebuilt when anything gets changed even if no Rust code in the project changed.

This uses `lib.fileset` to generate a workspace filter where only workspace members are included in the source for local crates.

I'm not sure if this will cause breakage for users, maybe we should put it behind a flag?