### PR TITLE
Use `.cargo/config.toml` instead of `.cargo/config`

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -177,7 +177,7 @@ let
 
     configureCargo = ''
       mkdir -p .cargo
-      cat > .cargo/config <<'EOF'
+      cat > .cargo/config.toml <<'EOF'
       [net]
       offline = true
       [target."${rustBuildTriple}"]


### PR DESCRIPTION
`.cargo/config` will be deprecated in Rust 1.78.

`.cargo/config.toml` has been supported since Rust 1.38.

https://github.com/rust-lang/cargo/pull/13349
