### PR TITLE
Configure cargo to avoid any network access

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -178,6 +178,8 @@ let
     configureCargo = ''
       mkdir -p .cargo
       cat > .cargo/config <<'EOF'
+      [net]
+      offline = true
       [target."${rustBuildTriple}"]
       linker = "${ccForBuild}"
     '' + optionalString (codegenOpts != null && codegenOpts ? "${rustBuildTriple}") (''


### PR DESCRIPTION
This became necessary starting with Rust nightly 2024-03-26. But it has never been a good idea to access network in Nix builds.

Both `--offline` and `net.offline` appeared in Rust 1.36.

https://github.com/rust-lang/cargo/pull/6934