### PR TITLE
Quote `$manifest_path` so it doesn't break comparison if empty

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -165,7 +165,7 @@ let
       manifest_path=$(cargoRelativeManifest ${name})
       manifest_dir=''${manifest_path%Cargo.toml}
 
-      if [ $manifest_path != "Cargo.toml" ]; then
+      if [ "$manifest_path" != "Cargo.toml" ]; then
         shopt -s globstar
         mv Cargo.toml Cargo.toml.workspace
         if [[ -d .cargo ]]; then


### PR DESCRIPTION
Something is likely wrong if `$manifest_path` is empty, but at least it won't trigger an unhelpful syntax error in bash.