### PR TITLE
Fix spelling of PKG_CONFIG_ALLOW_CROSS

### DIFF
--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -225,7 +225,7 @@ in rec {
         pkgs.pkg-config
       ];
       shellHook = drv.shellHook or "" + ''
-        export PGK_CONFIG_ALLOW_CROSS=1
+        export PKG_CONFIG_ALLOW_CROSS=1
       '';
     };
   };


### PR DESCRIPTION
Issue introduced in 2ae2f57353232344ceec889d9b2787e207961983