### PR TITLE
Refactor of toml munging

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -160,6 +160,7 @@ let
 
     extraRustcBuildFlags = rustcBuildFlags;
 
+    # If the crate is a workspace, reduce it to a crate of just a single workspace
     findCrate =  ''
       . ${./mkcrate-utils.sh}
       manifest_path=$(cargoRelativeManifest ${name})
@@ -167,11 +168,13 @@ let
 
       if [ "$manifest_path" != "Cargo.toml" ]; then
         shopt -s globstar
-        mv Cargo.toml Cargo.toml.workspace
         if [[ -d .cargo ]]; then
           mv .cargo .cargo.workspace
         fi
-        cd "$manifest_dir"
+
+        mv Cargo.toml Cargo.workspace.toml
+        sanitizeTomlForRemarshal Cargo.workspace.toml
+        reduceWorkspaceToml Cargo.workspace.toml Cargo.toml "$manifest_dir"
       fi
     '';
 
@@ -221,6 +224,9 @@ let
     };
 
     overrideCargoManifest = ''
+      manifest_path=$(cargoRelativeManifest ${name})
+      manifest_dir=''${manifest_path%Cargo.toml}
+
       echo "[[package]]" > Cargo.lock
       echo name = \"${name}\" >> Cargo.lock
       echo version = \"${version}\" >> Cargo.lock
@@ -229,9 +235,11 @@ let
         echo source = \"registry+''${registry}\" >> Cargo.lock
       fi
 
+      if [ -n "$manifest_dir" ]; then pushd $manifest_dir; fi
       mv Cargo.toml Cargo.original.toml
       sanitizeTomlForRemarshal Cargo.original.toml
-      removeTomlDeps Cargo.original.toml Cargo.toml "$manifestPatch"
+      reducePackageToml Cargo.original.toml Cargo.toml "$manifestPatch"
+      if [ -n "$manifest_dir" ]; then popd; fi
     '';
 
     setBuildEnv = ''
@@ -240,13 +248,13 @@ let
 
       if (( MINOR_RUSTC_VERSION < 41 )); then
         isProcMacro="$(
-          remarshal -if toml -of json Cargo.original.toml \
+          remarshal -if toml -of json "''${manifest_dir}Cargo.original.toml" \
           | jq -r 'if .lib."proc-macro" or .lib."proc_macro" then "1" else "" end' \
         )"
       fi
 
       crateName="$(
-        remarshal -if toml -of json Cargo.original.toml \
+        remarshal -if toml -of json "''${manifest_dir}Cargo.original.toml" \
         | jq -r 'if .lib."name" then .lib."name" else "${replaceStrings ["-"] ["_"] name}" end' \
       )"
 
@@ -309,7 +317,7 @@ let
       runHook preInstall
     '' + (if compileMode != "doctest" then ''
       mkdir -p $out/lib
-      cargo_links="$(remarshal -if toml -of json Cargo.original.toml | jq -r '.package.links | select(. != null)')"
+      cargo_links="$(remarshal -if toml -of json "''${manifest_dir}Cargo.original.toml" | jq -r '.package.links | select(. != null)')"
       if (( MINOR_RUSTC_VERSION < 41 )); then
         install_crate ${rustHostTriple} ${if release then "release" else "debug"}
       else

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -160,24 +160,6 @@ let
 
     extraRustcBuildFlags = rustcBuildFlags;
 
-    # If the crate is a workspace, reduce it to a crate of just a single workspace
-    findCrate =  ''
-      . ${./mkcrate-utils.sh}
-      manifest_path=$(cargoRelativeManifest ${name})
-      manifest_dir=''${manifest_path%Cargo.toml}
-
-      if [ "$manifest_path" != "Cargo.toml" ]; then
-        shopt -s globstar
-        if [[ -d .cargo ]]; then
-          mv .cargo .cargo.workspace
-        fi
-
-        mv Cargo.toml Cargo.workspace.toml
-        sanitizeTomlForRemarshal Cargo.workspace.toml
-        reduceWorkspaceToml Cargo.workspace.toml Cargo.toml "$manifest_dir"
-      fi
-    '';
-
     configureCargo = ''
       mkdir -p .cargo
       cat > .cargo/config <<'EOF'
@@ -213,7 +195,6 @@ let
 
     configurePhase = ''
       runHook preConfigure
-      runHook findCrate
       runHook configureCargo
       runHook postConfigure
     '';
@@ -224,9 +205,9 @@ let
     };
 
     overrideCargoManifest = ''
-      manifest_path=$(cargoRelativeManifest ${name})
-      manifest_dir=''${manifest_path%Cargo.toml}
+      . ${./mkcrate-utils.sh}
 
+      # Synthesize a lock file
       echo "[[package]]" > Cargo.lock
       echo name = \"${name}\" >> Cargo.lock
       echo version = \"${version}\" >> Cargo.lock
@@ -235,11 +216,23 @@ let
         echo source = \"registry+''${registry}\" >> Cargo.lock
       fi
 
+      manifest_path=$(cargoRelativeManifest ${name})
+      manifest_dir=''${manifest_path%Cargo.toml}
+
+      # Rewrite the crate's toml
       if [ -n "$manifest_dir" ]; then pushd $manifest_dir; fi
       mv Cargo.toml Cargo.original.toml
       sanitizeTomlForRemarshal Cargo.original.toml
       reducePackageToml Cargo.original.toml Cargo.toml "$manifestPatch"
       if [ -n "$manifest_dir" ]; then popd; fi
+
+      # If the crate is a workspace, reduce it to a crate of just a workspace of a single crate
+      if [ "$manifest_path" != "Cargo.toml" ]; then
+        mv Cargo.toml Cargo.workspace.toml
+        sanitizeTomlForRemarshal Cargo.workspace.toml
+        reduceWorkspaceToml Cargo.workspace.toml Cargo.toml "$manifest_dir"
+      fi
+
     '';
 
     setBuildEnv = ''

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -228,33 +228,10 @@ let
       if [ "$registry" != "unknown" ]; then
         echo source = \"registry+''${registry}\" >> Cargo.lock
       fi
+
       mv Cargo.toml Cargo.original.toml
-      # Remarshal was failing on table names of the form:
-      # [key."cfg(foo = \"a\", bar = \"b\"))".path]
-      # The regex to find or deconstruct these strings must find, in order,
-      # these components: open bracket, open quote, open escaped quote, and
-      # their closing pairs.  Because each quoted path can contain multiple
-      # quote escape pairs, a loop is employed to match the first quote escape,
-      # which the sed will replace with a single quote equivalent until all
-      # escaped quote pairs are replaced.  The grep regex is identical to the
-      # sed regex but does not destructure the match into groups for
-      # restructuring in the replacement.
-      while grep '\[[^"]*"[^\\"]*\\"[^\\"]*\\"[^"]*[^]]*\]' Cargo.original.toml; do
-        sed -i -r 's/\[([^"]*)"([^\\"]*)\\"([^\\"]*)\\"([^"]*)"([^]]*)\]/[\1"\2'"'"'\3'"'"'\4"\5]/g' Cargo.original.toml
-      done;
-      remarshal -if toml -of json Cargo.original.toml \
-        | jq "{ package: .package
-              , lib: .lib
-              , bin: .bin
-              , test: .test
-              , example: .example
-              , bench: (if \"$registry\" == \"unknown\" then .bench else null end)
-              }
-              | with_entries(select( .value != null ))
-              | del( .package.workspace )
-              + $manifestPatch" \
-        | jq "del(.[][] | nulls)" \
-        | remarshal -if json -of toml > Cargo.toml
+      sanitizeTomlForRemarshal Cargo.original.toml
+      removeTomlDeps Cargo.original.toml Cargo.toml "$manifestPatch"
     '';
 
     setBuildEnv = ''

--- a/templates/Cargo.nix.tera
+++ b/templates/Cargo.nix.tera
@@ -75,11 +75,7 @@ in
       {%- endif -%}
     };
     {%- elif crate.source.Local.path %}
-    {%- if crate.source.Local.path == "." %}
     src = fetchCrateLocal workspaceSrc;
-    {%- else %}
-    src = fetchCrateLocal (workspaceSrc + "/{{ crate.source.Local.path }}");
-    {%- endif %}
     {%- elif crate.source.Registry.index %}
     src = fetchCrateAlternativeRegistry {
       index = {{ crate.source.Registry.index }};
@@ -89,7 +85,7 @@ in
     };
     {%- else %}
     # ERROR: Could not resolve source: {{ crate.source | safe | json_encode() }}
-    {% endif -%}
+    {%- endif -%}
 
     {%- if crate.features | length > 0 %}
     features = builtins.concatLists [


### PR DESCRIPTION
```
*  Use entire workspace, begin refactor of toml munging

   The newer findCrate logic is accurate enough that we don't need to provide the
   source path, although we could re-visit this if some sources don't have a
   workspace in the source root.  Cargo still needs to be able to decide to use
   such a source in any case, or we can't generate the expression.

*  Sanitize workspace & package tomls

   Instead of the existing whitelist style jq statements, a blacklist is produced
   to eliminate keys that cause issues in sandbox builds or will conflict with
   configuration via nix expressions

   The workspace toml is reduced so that it becomes a workspace for just a single
   member, the crate we want to build.

   The crate toml is reduced separately.

   The build happens from the workspace level.

*  remove findCrate stage

   The method of using metadata to check for a workspace before munging the desired
   crate's toml needs to do so before we munge the workspace.

   It made sense to get rid of the extraneous phase, especially now that everything
   is refactored a bit.
```