### PR TITLE
Fix typos, remove outdated warning

### DIFF
--- a/examples/1-hello-world/README.md
+++ b/examples/1-hello-world/README.md
@@ -96,7 +96,7 @@ builds)
 In order to consume the `Cargo.nix` and provide outputs for `nix build` and
 other `nix` commands, you need to write a `flake.nix`
 
-The overally structure of a flake is very simple.  It's a nix expression that
+The overall structure of a flake is very simple.  It's a nix expression that
 describes `inputs` and `outputs`.  All of the inputs are usually other flakes.
 The output paths tell `nix` commands such as `nix develop` and `nix build` what
 to use to do their work.
@@ -184,8 +184,7 @@ than just flat declarations like a yaml file.
 
 The flake input for nixpkgs needs to be instantiated into an actual nixpkgs.
 The [overlays] inject some extras, like the `rust-bin` set of Rust toolchains
-and functions like `rustBuilder.makePackageSet`.  **Note the single quote in
-the name!**
+and functions like `rustBuilder.makePackageSet`.
 
 [overlays]: https://nixos.wiki/wiki/Overlays
 
@@ -213,7 +212,7 @@ The structure of `rustPkgs` is organized as follows:
 # Source -----------------+          |         |     |
 #  - Crates.io URL                   |         |     |
 #  - Git repository URL              |         |     |
-#  - Alterative registry URL         |         |     |
+#  - Alternative registry URL        |         |     |
 #  - `unknown` for path deps         |         |     |
 #                                    |         |     |
 #                Name ---------------+         |     |

--- a/examples/4-independent-packaging/README.md
+++ b/examples/4-independent-packaging/README.md
@@ -5,7 +5,7 @@ hosting repository.  This example uses flakes.
 
 ## Introduction
 
-It's not always desireable or best to nixify projects by embedding nix files
+It's not always desirable or best to nixify projects by embedding nix files
 into their repositories. This is in fact avoided in nixpkgs. Instead, you can
 ship a pre-made Cargo.nix and a default.nix that locates and provides the
 external source to produce a build.  Rust Analyzer is packaged here as a
@@ -93,7 +93,7 @@ derivation for our binary:
 #### Multiple Outputs
 
 Each derivation created by `mkRustCrate` contains multiple outputs.  The `bin`
-attribute is the default and contains just the executible compiler artifacts
+attribute is the default and contains just the executable compiler artifacts
 (using cargo metadata output).  By default only the `bin` output is installed,
 but you can also use `out` to see the intermediate linking information and other
 libraries created during the build. The `out` attribute contains extra files

--- a/overlay/make-package-set/user-facing.nix
+++ b/overlay/make-package-set/user-facing.nix
@@ -44,7 +44,7 @@ let
 
   # Normalize the toolchain args and build a toolchain or used the provided
   # toolchain.  This logic is a bit complicated by legacy use of "rustChannel"
-  # wich could be a version string in previous eras.  Can deprecate at some
+  # which could be a version string in previous eras.  Can deprecate at some
   # point after pointing everyone to correct usage.  Note that rustToolchain
   # comes from buildPackages.rust-bin.  The overlay has been applied and
   # returned via callPackage.

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -88,13 +88,13 @@ let
           1> >(jq 'select(.message != null) .message.rendered' -r)
       ''
       # Note: Doctest doesn't yet support no-run https://github.com/rust-lang/rust/pull/83857
-      # So instead of persiting the binaries with
+      # So instead of persisting the binaries with
       # RUSTDOCFLAGS="-Zunstable-options --persist-doctests $(pwd)/target/rustdoctest -o $(pwd)/target/rustdoctest" cargo test --doc | tee .cargo-doctest-output
       # we just introduce a new compile mode
       #
       # We also filter -l linkage flags, as rustdoc doesn't support them
       #
-      # And _also_ detect if there are no lib crates, in which case skip, because thats an error for rustdoc
+      # And _also_ detect if there are no lib crates, in which case skip, because that's an error for rustdoc
       #
       # This does not abort on failure. The output should be inspected for failures
       else ''


### PR DESCRIPTION
`makePackageSet` used to be `makePackageSet'` before 7805130bbfb56b40390c868425c17ab050d10134. There is no single quote in that name anymore.