### PR TITLE
fix pq-sys shellHook override

### DIFF
--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -243,7 +243,7 @@ in rec {
           nativeBuildInputs = drv.nativeBuildInputs or [ ] ++ [
             fake_pg_config
           ];
-          shellHook = drv.shellHook + ''
+          shellHook = drv.shellHook or "" + ''
             PG_CONFIG_${envize pkgs.stdenv.buildPlatform.config}="${fake_pg_config}"
           '';
         };


### PR DESCRIPTION
Eval would fail when pq-sys is used as
`drv.shellHook` is missing. Other places seem to
properly handle the missing attribute.
