### PR TITLE
add note about using newer rust versions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ what the current output result is.
 how we store information in dependents and replay them back when
 building dependents.  It is vital for building crates in isolation.
 
-#### Newer rust versions
+## Newer Rust versions
 
-In order to use newer rust versions you can include
+In order to use the latest Rust versions you may need to include
 [rust-overlay](https://github.com/oxalica/rust-overlay) directly in your flake
 like so:
 
@@ -207,15 +207,17 @@ like so:
 {
   inputs = {
     rust-overlay.url = "github:oxalica/rust-overlay/stable";
-    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
-
-    cargo2nix.url = "github:cargo2nix/cargo2nix/release-0.11.0";
-    cargo2nix.inputs.nixpkgs.follows = "nixpkgs";
-    cargo2nix.inputs.flake-utils.follows = "flake-utils";
-    cargo2nix.inputs.rust-overlay.follows = "rust-overlay";
+    cargo2nix = {
+      url = "github:cargo2nix/cargo2nix/release-0.11.0";
+      inputs.rust-overlay.follows = "rust-overlay";
+    };
   };
 }
 ```
+
+To use a Rust version that was released after you added the rust-overlay input
+you will need to run `nix flake update rust-overlay` to get the latest
+rust-overlay version.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,26 @@ what the current output result is.
 how we store information in dependents and replay them back when
 building dependents.  It is vital for building crates in isolation.
 
+#### Newer rust versions
+
+In order to use newer rust versions you can include
+[rust-overlay](https://github.com/oxalica/rust-overlay) directly in your flake
+like so:
+
+```nix
+{
+  inputs = {
+    rust-overlay.url = "github:oxalica/rust-overlay/stable";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+
+    cargo2nix.url = "github:cargo2nix/cargo2nix/release-0.11.0";
+    cargo2nix.inputs.nixpkgs.follows = "nixpkgs";
+    cargo2nix.inputs.flake-utils.follows = "flake-utils";
+    cargo2nix.inputs.rust-overlay.follows = "rust-overlay";
+  };
+}
+```
+
 ## How it works
 
 - The `cargo2nix` utility reads the Rust workspace configuration and


### PR DESCRIPTION
i was frustrated that i had to look through the code to see how to use newer rust versions to find out that i just needed to update the rust-overlay version through my flake so i added the steps to do that in the readme if thats ok

as per #379 and #181 it seems that currently only versions up until verison 1.78 work so maybe i should add that disclaimer as well?