### PR TITLE
generate .cargo/config.toml on supported rust compilers

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -177,7 +177,7 @@ let
 
     configureCargo = ''
       mkdir -p .cargo
-      cat > .cargo/config <<'EOF'
+      cat > .cargo/config${if lib.versionOlder rustToolchain.version "1.39.0" then "" else "toml"} <<'EOF'
       [net]
       offline = true
       [target."${rustBuildTriple}"]


### PR DESCRIPTION
1.39.0 introduced a new supported file name for the cargo config file, and it recently turned into a warning if you still use the old .cargo/config file.

This change will automatically use .cargo/config.toml for rustc compilers that are version 1.39.0 or newer.
