### PR TITLE
Respect config.toml

### DIFF
--- a/examples/1-hello-world/Cargo.nix
+++ b/examples/1-hello-world/Cargo.nix
@@ -22,6 +22,7 @@ args@{
   lib,
   workspaceSrc,
   ignoreLockHash,
+  cargoConfig ? {},
 }:
 let
   nixifiedLockHash = "86421e8411c52265e52f81b8472270ebd2bf444f999c0a881d1c544b4e8a0d29";
@@ -34,12 +35,18 @@ in if !lockHashIgnored && (nixifiedLockHash != currentLockHash) then
   throw ("Cargo.nix ${nixifiedLockHash} is out of sync with Cargo.lock ${currentLockHash}")
 else let
   inherit (rustLib) fetchCratesIo fetchCrateLocal fetchCrateGit fetchCrateAlternativeRegistry expandFeatures decideProfile genDrvsByProfile;
+  cargoConfig' = if cargoConfig != {} then cargoConfig else
+                 if builtins.pathExists ./.cargo/config then lib.importTOML ./.cargo/config else
+                 if builtins.pathExists ./.cargo/config.toml then lib.importTOML ./.cargo/config.toml else {};
   profilesByName = {
   };
   rootFeatures' = expandFeatures rootFeatures;
   overridableMkRustCrate = f:
     let
-      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures target profileOpts codegenOpts cargoUnstableFlags rustcLinkFlags rustcBuildFlags; } // (f profileName)));
+      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({
+        inherit release profile hostPlatformCpu hostPlatformFeatures target profileOpts codegenOpts cargoUnstableFlags rustcLinkFlags rustcBuildFlags; 
+        cargoConfig = cargoConfig';
+      } // (f profileName)));
     in { compileMode ? null, profileName ? decideProfile compileMode release }:
       let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in

--- a/examples/2-bigger-project/Cargo.nix
+++ b/examples/2-bigger-project/Cargo.nix
@@ -22,6 +22,7 @@ args@{
   lib,
   workspaceSrc,
   ignoreLockHash,
+  cargoConfig ? {},
 }:
 let
   nixifiedLockHash = "156d68c50b2caffb735aa9279e09fd6009a1d7bbf41863900d31309cf6b1f045";
@@ -34,12 +35,18 @@ in if !lockHashIgnored && (nixifiedLockHash != currentLockHash) then
   throw ("Cargo.nix ${nixifiedLockHash} is out of sync with Cargo.lock ${currentLockHash}")
 else let
   inherit (rustLib) fetchCratesIo fetchCrateLocal fetchCrateGit fetchCrateAlternativeRegistry expandFeatures decideProfile genDrvsByProfile;
+  cargoConfig' = if cargoConfig != {} then cargoConfig else
+                 if builtins.pathExists ./.cargo/config then lib.importTOML ./.cargo/config else
+                 if builtins.pathExists ./.cargo/config.toml then lib.importTOML ./.cargo/config.toml else {};
   profilesByName = {
   };
   rootFeatures' = expandFeatures rootFeatures;
   overridableMkRustCrate = f:
     let
-      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures target profileOpts codegenOpts cargoUnstableFlags rustcLinkFlags rustcBuildFlags; } // (f profileName)));
+      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({
+        inherit release profile hostPlatformCpu hostPlatformFeatures target profileOpts codegenOpts cargoUnstableFlags rustcLinkFlags rustcBuildFlags; 
+        cargoConfig = cargoConfig';
+      } // (f profileName)));
     in { compileMode ? null, profileName ? decideProfile compileMode release }:
       let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in

--- a/examples/3-cross-compiling/Cargo.nix
+++ b/examples/3-cross-compiling/Cargo.nix
@@ -22,6 +22,7 @@ args@{
   lib,
   workspaceSrc,
   ignoreLockHash,
+  cargoConfig ? {},
 }:
 let
   nixifiedLockHash = "c787740d469acf71a36abd0a236a69f5b797b67eff93b9b6bd0321ea533a45ef";
@@ -34,12 +35,18 @@ in if !lockHashIgnored && (nixifiedLockHash != currentLockHash) then
   throw ("Cargo.nix ${nixifiedLockHash} is out of sync with Cargo.lock ${currentLockHash}")
 else let
   inherit (rustLib) fetchCratesIo fetchCrateLocal fetchCrateGit fetchCrateAlternativeRegistry expandFeatures decideProfile genDrvsByProfile;
+  cargoConfig' = if cargoConfig != {} then cargoConfig else
+                 if builtins.pathExists ./.cargo/config then lib.importTOML ./.cargo/config else
+                 if builtins.pathExists ./.cargo/config.toml then lib.importTOML ./.cargo/config.toml else {};
   profilesByName = {
   };
   rootFeatures' = expandFeatures rootFeatures;
   overridableMkRustCrate = f:
     let
-      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures target profileOpts codegenOpts cargoUnstableFlags rustcLinkFlags rustcBuildFlags; } // (f profileName)));
+      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({
+        inherit release profile hostPlatformCpu hostPlatformFeatures target profileOpts codegenOpts cargoUnstableFlags rustcLinkFlags rustcBuildFlags; 
+        cargoConfig = cargoConfig';
+      } // (f profileName)));
     in { compileMode ? null, profileName ? decideProfile compileMode release }:
       let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in

--- a/overlay/make-package-set/internal.nix
+++ b/overlay/make-package-set/internal.nix
@@ -27,6 +27,7 @@
   rustcBuildFlags ? [],
   ignoreLockHash,
   targetInfo,
+  cargoConfig
 }:
 lib.fix' (self:
   let
@@ -53,7 +54,7 @@ lib.fix' (self:
     mkRustCrate' = lib.makeOverridable (callPackage mkRustCrate { inherit rustLib; });
     combinedOverride = builtins.foldl' rustLib.combineOverrides rustLib.nullOverride packageOverrides;
     packageFunWith = { mkRustCrate, buildRustPackages }: lib.fix (rustPackages: packageFun {
-      inherit rustPackages buildRustPackages lib workspaceSrc target profileOpts codegenOpts cargoUnstableFlags rustcLinkFlags rustcBuildFlags ignoreLockHash;
+      inherit rustPackages buildRustPackages lib workspaceSrc target profileOpts codegenOpts cargoUnstableFlags rustcLinkFlags rustcBuildFlags ignoreLockHash cargoConfig;
       hostPlatform = stdenv.hostPlatform // {
         cargo2nix = targetInfo;
       };

--- a/overlay/make-package-set/user-facing.nix
+++ b/overlay/make-package-set/user-facing.nix
@@ -21,6 +21,7 @@ args@{
   ignoreLockHash ? false,
   targetSpecFile ? if builtins.isPath target then target else null,
   targetSpec ? if targetSpecFile != null then lib.importJSON targetSpecFile else null,
+  cargoConfig ? {},
   ...
 }:
 let
@@ -120,11 +121,11 @@ let
 # performed.  Note that buildRustPackages is just buildPackages with a null
 # target.
 in rustBuilder.makePackageSetInternal (extraArgs // {
-  inherit packageFun ignoreLockHash workspaceSrc target targetInfo;
+  inherit packageFun ignoreLockHash workspaceSrc target targetInfo cargoConfig;
   rustToolchain = rustToolchain';
   packageOverrides = packageOverrides' pkgs;
   buildRustPackages = buildPackages.rustBuilder.makePackageSetInternal (extraArgs // {
-    inherit packageFun ignoreLockHash workspaceSrc targetInfo;
+    inherit packageFun ignoreLockHash workspaceSrc targetInfo cargoConfig;
     rustToolchain = rustToolchain';
     target = null;
     packageOverrides = packageOverrides' buildPackages;

--- a/overlay/mkcrate-nobuild.nix
+++ b/overlay/mkcrate-nobuild.nix
@@ -21,6 +21,7 @@
   target ? null,
   codegenOpts,
   profileOpts,
+  cargoConfig ? {}
 }:
 with lib; with builtins;
 let

--- a/templates/Cargo.nix.tera
+++ b/templates/Cargo.nix.tera
@@ -24,6 +24,7 @@ args@{
   lib,
   workspaceSrc,
   ignoreLockHash,
+  cargoConfig ? {},
 }:
 let
   nixifiedLockHash = "{{ cargo_lock_hash }}";
@@ -36,6 +37,9 @@ in if !lockHashIgnored && (nixifiedLockHash != currentLockHash) then
   throw ("Cargo.nix ${nixifiedLockHash} is out of sync with Cargo.lock ${currentLockHash}")
 else let
   inherit (rustLib) fetchCratesIo fetchCrateLocal fetchCrateGit fetchCrateAlternativeRegistry expandFeatures decideProfile genDrvsByProfile;
+  cargoConfig' = if cargoConfig != {} then cargoConfig else
+                 if builtins.pathExists ./.cargo/config then lib.importTOML ./.cargo/config else
+                 if builtins.pathExists ./.cargo/config.toml then lib.importTOML ./.cargo/config.toml else {};
   profilesByName = {
   {%- for name, profile in profiles %}
     {{ name }} = builtins.fromTOML "{{ profile }}";
@@ -44,7 +48,10 @@ else let
   rootFeatures' = expandFeatures rootFeatures;
   overridableMkRustCrate = f:
     let
-      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures target profileOpts codegenOpts cargoUnstableFlags rustcLinkFlags rustcBuildFlags; } // (f profileName)));
+      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({
+        inherit release profile hostPlatformCpu hostPlatformFeatures target profileOpts codegenOpts cargoUnstableFlags rustcLinkFlags rustcBuildFlags; 
+        cargoConfig = cargoConfig';
+      } // (f profileName)));
     in { compileMode ? null, profileName ? decideProfile compileMode release }:
       let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in


### PR DESCRIPTION
This change automatically applies the `.cargo/config.toml` settings found in the repository root. to accomplish this I have rewritten the config.toml generation logic to use the nix toml generators, instead of generating it inline.

Fixes #181.