### PR TITLE
Add support for workspaces with root package

### DIFF
--- a/overlay/mkcrate-utils.sh
+++ b/overlay/mkcrate-utils.sh
@@ -359,7 +359,8 @@ reducePackageToml () {
                 .dependencies,
                 ."build-dependencies",
                 .["dev-dependencies"],
-                .target)
+                .target,
+                .workspace)
             + '"$manifestPatch" \
             | jq 'del(.[][] | nulls)' \
             | remarshal -if json -of toml > "$2"
@@ -372,11 +373,10 @@ reduceWorkspaceToml () {
     local crate_path="$3"
     remarshal -if toml -of json $1 \
       | jq ".workspace.members = [\"$crate_path\"]
+            | { workspace: .workspace, profile: .profile }
             | del( .workspace.dependencies?,
                    .workspace.\"default-members\",
-                   .workspace.exclude?,
-                   .patch,
-                   .replace)
+                   .workspace.exclude?)
             | with_entries(select( .value != null ))" \
       | jq "del(.[][] | nulls)" \
       | remarshal -if json -of toml > $2


### PR DESCRIPTION
The Cargo.toml munging code did not correctly disect packages where there is a root packages and several sub-packages.

Now all package-related Cargo.toml options are removed from workspace manifests and all workspace-related Cargo.toml options are removed from package manifests

This fixes #392.

@halletj, after we merge this we should cut a 0.12.0. users are getting confused about why the current release version is broken